### PR TITLE
Fewer symlinks; relpaths

### DIFF
--- a/src/pbfalcon/chunk.py
+++ b/src/pbfalcon/chunk.py
@@ -18,10 +18,11 @@ def symlink(actual):
     """Symlink into cwd, using basename.
     """
     symbolic = os.path.basename(actual)
-    lg('ln -s %s %s' %(actual, symbolic))
+    rel = os.path.relpath(actual)
+    lg('ln -s %s %s' %(rel, symbolic))
     if os.path.lexists(symbolic):
         os.unlink(symbolic)
-    os.symlink(actual, symbolic)
+    os.symlink(rel, symbolic)
 
 def symlink_dazzdb(actualdir, db_prefix):
     """Symlink elements of dazzler db.

--- a/src/pbfalcon/cli/gen_config.py
+++ b/src/pbfalcon/cli/gen_config.py
@@ -18,11 +18,11 @@ def add_args_and_options(p):
     p.add_output_file_type(FileTypes.TXT, "cfg_out", "INI File", "FALCON cfg (aka 'ini')", 'fc_run.cfg')
     # Option id, label, default value, name, description
     p.add_str("falcon_ns.task_options." + gen_config.OPTION_GENOME_LENGTH, "genome-length", '5000000',
-            "Genome length (base pairs)", "Approx. number of base pairs expected in the genome.")
+            "Genome length (base pairs) REQUIRED", "Approx. number of base pairs expected in the genome. We choose other settings automatically, based on this. (To learn what we generate, see fc_*.cfg, currently called 'falcon_ns.tasks.task_falcon0_build_rdb-PacBio.FileTypes.txt' amongst output files.)")
     p.add_str("falcon_ns.task_options." + gen_config.OPTION_CORES_MAX, "cores-max", '40',
-            "Cores Max.", "Maximum number of cores to use simultaneously across the network. For any given Task, this setting might further reduce the number of 'chunks', beneather the global maximum. Note that a Task can use multiple cores in 2 ways: processes and threads. You can assume that our Tasks honestly report what they expect to consume.")
-    p.add_str("falcon_ns.task_options." + gen_config.OPTION_CFG, "falcon-advanced", '',
-            "FALCON cfg overrides", "This is intended to allow support engineers to overrides the config which we will generate from other options. It is a semicolon-separated list of key=val pairs. Newlines are allowed by ignored. For more details on the available options, see https://github.com/PacificBiosciences/FALCON/wiki/Manual")
+            "Cores Max IGNORED.", "IGNORE - not currently used")
+    p.add_str("falcon_ns.task_options." + gen_config.OPTION_CFG, "falcon-overrides", '',
+            "FALCON cfg overrides", "This is intended to allow support engineers to override the cfg which we will generate from other options. It is a semicolon-separated list of key=val pairs. Newlines are allowed but ignored. For more details on the available options, see https://github.com/PacificBiosciences/FALCON/wiki/Manual")
     return p
 
 def get_contract_parser():

--- a/src/pbfalcon/gen_config.py
+++ b/src/pbfalcon/gen_config.py
@@ -154,19 +154,18 @@ def get_falcon_overrides(cfg_content, OPTION_CFG=OPTION_CFG):
 
 def run_falcon_gen_config(input_files, output_files, options):
     """Generate a config-file from options.
-
-    TODO(CD):
-    Eventually, use GenomeSize and ParallelTasksMax too.
-    Also, validate cfg, in case of missing options.
     """
     i_fofn_fn, = input_files
     o_cfg_fn, = output_files
     import pprint
     log.info('options to run_falcon_gen_config:\n{}'.format(pprint.pformat(options)))
+    print('options to run_falcon_gen_config:\n{}'.format(pprint.pformat(options)))
     options = _options_dict_with_base_keys(options)
     falcon_options = _populate_falcon_options(options)
+    print('falcon_options to run_falcon_gen_config:\n{}'.format(pprint.pformat(falcon_options)))
     if OPTION_CFG in options:
         overrides = get_falcon_overrides(options[OPTION_CFG], OPTION_CFG)
+        print('overrides:\n%s'% pprint.pformat(overrides))
         falcon_options.update(overrides)
     else:
         raise Exception("Could not find %s" %OPTION_CFG)

--- a/src/pbfalcon/tusks.py
+++ b/src/pbfalcon/tusks.py
@@ -128,10 +128,10 @@ def run_daligner_jobs(input_files, output_files, db_prefix='raw_reads'):
     db_dir = os.path.dirname(run_daligner_job_fn)
     cmds = ['pwd', 'ls -al']
     fns = ['.{pre}.bps', '.{pre}.idx', '{pre}.db']
-    cmds += ['rm -f %s' %fn for fn in fns]
+    cmds += [r'\rm -f %s' %fn for fn in fns]
     cmds += ['ln -sf {dir}/%s .' %fn for fn in fns]
     cmd = ';'.join(cmds).format(
-            dir=db_dir, pre=db_prefix)
+            dir=os.path.relpath(db_dir), pre=db_prefix)
     run_cmd(cmd, sys.stdout, sys.stderr, shell=True)
     cwd = os.getcwd()
     config = _get_config_from_json_fileobj(open(i_json_config_fn))
@@ -198,7 +198,7 @@ def run_merge_consensus_jobs(input_files, output_files, db_prefix='raw_reads'):
     cmds += ['rm -f %s' %fn for fn in fns]
     cmds += ['ln -sf {dir}/%s .' %fn for fn in fns]
     cmd = ';'.join(cmds).format(
-            dir=db_dir, pre=db_prefix)
+            dir=os.path.relpath(db_dir), pre=db_prefix)
     run_cmd(cmd, sys.stdout, sys.stderr, shell=True)
     cwd = os.getcwd()
     config = _get_config_from_json_fileobj(open(i_json_config_fn))
@@ -269,8 +269,9 @@ def create_merge_tasks(i_fofn_fn, run_jobs_fn, wd, db_prefix, config):
             # Since we could be in the gather-task-dir, instead of globbing,
             # we will read the fofn.
             for fn in open(i_fofn_fn).read().splitlines():
-                print("symlink %r <- %r" %(fn, os.path.basename(fn)))
-                os.symlink(fn, os.path.basename(fn))
+                rel_fn = os.path.relpath(fn)
+                print("symlink %r <- %r" %(rel_fn, os.path.basename(fn)))
+                os.symlink(rel_fn, os.path.basename(fn))
 
         merge_script_file = os.path.abspath( "%s/m_%05d/m_%05d.sh" % (wd, p_id, p_id) )
         with open(merge_script_file, "w") as merge_script:

--- a/src/pbfalcon/tusks.py
+++ b/src/pbfalcon/tusks.py
@@ -153,11 +153,6 @@ def create_daligner_tasks(run_jobs_fn, wd, db_prefix, db_file, config, pread_aln
 
     nblock = support2.get_nblock(db_file)
 
-    # Not in other version. Still needed?
-    for pid in xrange(1, nblock + 1):
-        # support.run_daligner() links into this at end. Maybe we should change that.
-        support.make_dirs("%s/m_%05d" % (wd, pid))
-
     re_daligner = re.compile(r'\bdaligner\b')
 
     line_count = 0

--- a/src/pbfalcon/tusks.py
+++ b/src/pbfalcon/tusks.py
@@ -256,6 +256,9 @@ def create_merge_tasks(i_fofn_fn, run_jobs_fn, wd, db_prefix, config):
                     mjob_data.setdefault( p_id, [] )
                     mjob_data[p_id].append(  " ".join(l) )
 
+    # Could be L1.* or preads.*
+    re_las = re.compile(r'\.(\d*)(\.\d*)?\.las$')
+
     for p_id in mjob_data:
         s_data = mjob_data[p_id]
 
@@ -269,6 +272,14 @@ def create_merge_tasks(i_fofn_fn, run_jobs_fn, wd, db_prefix, config):
             # Since we could be in the gather-task-dir, instead of globbing,
             # we will read the fofn.
             for fn in open(i_fofn_fn).read().splitlines():
+                basename = os.path.basename(fn)
+                mo = re_las.search(basename)
+                if not mo:
+                    continue
+                left_block = int(mo.group(1))
+                if left_block != p_id:
+                    # By convention, m_00005 merges L1.5.*.las, etc.
+                    continue
                 rel_fn = os.path.relpath(fn)
                 print("symlink %r <- %r" %(rel_fn, os.path.basename(fn)))
                 os.symlink(rel_fn, os.path.basename(fn))


### PR DESCRIPTION
This fixes a bug where we produce orders of magnitude more symlinks than necessary. It's not a problem for lambda, but it's good to have.

This also uses relpath for symlinks to make the job-tree nearly relocatable. (The FOFN files still have absolute paths, and probably the resolved-tool-contracts too.)

Also, there are cosmetic changes in docs. The GUI API is unchanged, I think. (Depends on how command-line arguments are treated.) So be safe, we'll update the GUI templates, but it shouldn't matter.