### PR TITLE
Abide pbsmrtpipe.options.max_nchunks

### DIFF
--- a/src/pbfalcon/chunk.py
+++ b/src/pbfalcon/chunk.py
@@ -2,6 +2,7 @@
 from falcon_kit.functional import (get_daligner_job_descriptions, get_script_xformer)
 from pbcommand.models import PipelineChunk
 from pbcommand.pb_io import write_pipeline_chunks
+from .functional import joined_strs
 import logging
 import os
 import re
@@ -49,8 +50,9 @@ def write_run_daligner_chunks_falcon(
         # cmds is actually a list of small bash scripts, including linefeeds.
         cmds = get_daligner_job_descriptions(open(run_jobs_fn), db_prefix).values()
         if max_total_nchunks < len(cmds):
-            raise Exception("max_total_nchunks < # daligner cmds: %d < %d" %(
+            log.debug("max_total_nchunks < # daligner cmds: %d < %d" %(
                 max_total_nchunks, len(cmds)))
+            cmds = joined_strs(cmds, max_total_nchunks)
         symlink_dazzdb(os.path.dirname(run_jobs_fn), db_prefix)
         for i, script in enumerate(cmds):
             chunk_id = '_'.join([chunk_base_name, str(i)])

--- a/src/pbfalcon/functional.py
+++ b/src/pbfalcon/functional.py
@@ -25,3 +25,17 @@ def fns_from_fofn(fofn):
         if not fn:
             continue
         yield fn
+
+def joined_strs(pieces, olen):
+    """Reduce len to olen by joining some strings.
+
+    >>> list(joined_strs(['a', 'b', 'c'], 2))
+    ['ab', 'c']
+    """
+    ilen = len(pieces)
+    rem = ilen
+    while rem:
+        n = ((rem-1)//olen) + 1
+        yield ''.join(pieces[ilen-rem : n+ilen-rem])
+        rem -= n
+        olen -= 1

--- a/utest/test_functional.py
+++ b/utest/test_functional.py
@@ -28,3 +28,21 @@ c.d
     expected = ['a-b', 'c.d']
     got = list(func.fns_from_fofn(fofn))
     assert_equal(expected, got)
+
+def test_joined_strs():
+    def verify(args, expected):
+        got = func.joined_strs(*args)
+        assert_equal(list(got), list(expected))
+    yield verify, ([], 1), []
+    yield verify, (['a'], 1), ['a']
+    yield verify, (['a'], 2), ['a']
+    yield verify, (['a', 'b'], 1), ['ab']
+    yield verify, (['a', 'b'], 2), ['a', 'b']
+    yield verify, (['a', 'b'], 3), ['a', 'b']
+    yield verify, (['a', 'b', 'c'], 1), ['abc']
+    yield verify, (['a', 'b', 'c'], 2), ['ab', 'c']
+    yield verify, (['a', 'b', 'c'], 3), ['a', 'b', 'c']
+    yield verify, (['a', 'b', 'c', 'd'], 1), ['abcd']
+    yield verify, (['a', 'b', 'c', 'd'], 2), ['ab', 'cd']
+    yield verify, (['a', 'b', 'c', 'd'], 3), ['ab', 'c', 'd']
+    yield verify, (['a', 'b', 'c', 'd'], 4), ['a', 'b', 'c', 'd']


### PR DESCRIPTION
`joined_strs()` is generally useful in combining n scripts into m scripts, when m < n.

This will let us use pbsmrtpipe on larger genomes. It was easier than I'd expected for daligner. However, we are not yet chunking the merge/consensus task, which could be trickier.

I've tested this in pbsmrtpipe by restricting the number of chunks and increasing the number of daligner jobs for my 5kB test-case.

For anyone who has never seen "generator tests" in **nose**:
```
$ nosetests utest/test_functional.py -v
test_functional.test_calc_cutoff(0, 3) ... ok
test_functional.test_calc_cutoff(12, 3) ... ok
test_functional.test_calc_cutoff(13, 2) ... ok
test_functional.test_calc_cutoff(20, 1) ... ok
test_functional.test_total_length ... ok
test_functional.test_fns_from_fofn ... ok
test_functional.test_joined_strs(([], 1), []) ... ok
test_functional.test_joined_strs((['a'], 1), ['a']) ... ok
test_functional.test_joined_strs((['a'], 2), ['a']) ... ok
test_functional.test_joined_strs((['a', 'b'], 1), ['ab']) ... ok
test_functional.test_joined_strs((['a', 'b'], 2), ['a', 'b']) ... ok
test_functional.test_joined_strs((['a', 'b'], 3), ['a', 'b']) ... ok
test_functional.test_joined_strs((['a', 'b', 'c'], 1), ['abc']) ... ok
test_functional.test_joined_strs((['a', 'b', 'c'], 2), ['ab', 'c']) ... ok
test_functional.test_joined_strs((['a', 'b', 'c'], 3), ['a', 'b', 'c']) ... ok
test_functional.test_joined_strs((['a', 'b', 'c', 'd'], 1), ['abcd']) ... ok
test_functional.test_joined_strs((['a', 'b', 'c', 'd'], 2), ['ab', 'cd']) ... ok
test_functional.test_joined_strs((['a', 'b', 'c', 'd'], 3), ['ab', 'c', 'd']) ... ok
test_functional.test_joined_strs((['a', 'b', 'c', 'd'], 4), ['a', 'b', 'c', 'd']) ... ok

----------------------------------------------------------------------
Ran 19 tests in 0.004s

OK
```