### PR TITLE
Full hgap

### DIFF
--- a/pbfalcon/gen_config.py
+++ b/pbfalcon/gen_config.py
@@ -39,12 +39,12 @@ genome_size = 48000
 falcon_sense_option = --output_multi --min_idt 0.70 --min_cov 4 --max_n_read 200 --n_core 6
 length_cutoff = -1
 length_cutoff_pr = 12000
-pa_DBsplit_option = -x500 -s50
+pa_DBsplit_option = -x500 -s50 -a
 pa_HPCdaligner_option = -v -dal4 -t16 -e.70 -l1000 -s1000
 pa_concurrent_jobs = 32
 overlap_filtering_setting = --max_diff 100 --max_cov 50 --min_cov 1 --bestn 10 --n_core 24
 ovlp_HPCdaligner_option = -v -dal4 -t32 -h60 -e.96 -l500 -s1000
-ovlp_DBsplit_option = -x500 -s50
+ovlp_DBsplit_option = -x500 -s50 -a
 ovlp_concurrent_jobs = 32
 """
 # These values will need more adjusting, but at least they worked on some dataset.
@@ -73,9 +73,9 @@ length_cutoff = -1
 length_cutoff_pr = 500
 falcon_sense_option = --output_multi --min_idt 0.70 --min_cov 4 --max_n_read 200 --n_core 6
 overlap_filtering_setting = --max_diff 60 --max_cov 100 --min_cov 4 --bestn 10 --n_core 4
-ovlp_dbsplit_option = -x500 -s200
+ovlp_dbsplit_option = -x500 -s200 -a
 ovlp_hpcdaligner_option = -v -dal24 -t16 -h35 -e.93 -l1000 -s100 -k25
-pa_dbsplit_option =   -x500 -s200
+pa_dbsplit_option =   -x500 -s200 -a
 pa_hpcdaligner_option =   -v -dal24 -t14 -h70 -e.75 -l1000 -s100 -k18
 """
 defaults_yeast = """

--- a/pbfalcon/hgap_prepare.py
+++ b/pbfalcon/hgap_prepare.py
@@ -33,6 +33,13 @@ DEFAULT_LOGGING_CFG = {
     'filters': {
     },
     'handlers': {
+        'handler_file_all': {
+            'class': 'logging.FileHandler',
+            'level': 'DEBUG',
+            'formatter': 'format_full',
+            'filename': 'all.log',
+            'mode': 'w',
+        },
         'handler_file_pypeflow': {
             'class': 'logging.FileHandler',
             'level': 'INFO',
@@ -67,7 +74,7 @@ DEFAULT_LOGGING_CFG = {
         },
     },
     'root': {
-        'handlers': ['handler_stream'],
+        'handlers': ['handler_stream', 'handler_file_all'],
         'level': 'NOTSET',
     },
     'disable_existing_loggers': False

--- a/pbfalcon/pypeflow/flow.py
+++ b/pbfalcon/pypeflow/flow.py
@@ -3,6 +3,7 @@ from .. import sys
 
 from pbcore.io import (SubreadSet, HdfSubreadSet, FastaReader, FastaWriter,
                        FastqReader, FastqWriter)
+from pypeflow.pwatcher_bridge import PypeProcWatcherWorkflow, MyFakePypeThreadTaskBase
 from pypeflow.controller import PypeThreadWorkflow
 from pypeflow.data import PypeLocalFile, makePypeLocalFile, fn
 from pypeflow.task import PypeTask, PypeThreadTaskBase
@@ -13,6 +14,11 @@ import os
 import cStringIO
 
 log = logging.getLogger(__name__)
+
+#PypeWorkflow = PypeThreadWorkflow
+#PypeTaskBase = PypeThreadTaskBase
+PypeWorkflow = PypeProcWatcherWorkflow
+PypeTaskBase = MyFakePypeThreadTaskBase
 
 def say(x):
     log.warning(x)
@@ -257,7 +263,10 @@ def flow(config):
     #wf.refreshTargets(exitOnFailure=exitOnFailure)
     #concurrent_jobs = config["pa_concurrent_jobs"]
     #PypeThreadWorkflow.setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
-    wf = PypeThreadWorkflow()
+    #wf = PypeThreadWorkflow()
+    #wf = PypeWorkflow()
+    #wf = PypeWorkflow(job_type='local')
+    wf = PypeWorkflow(job_type=config['job_type'])
 
     dataset_pfn = makePypeLocalFile(config['pbsmrtpipe']['input_files'][0])
     fdataset_pfn = makePypeLocalFile('filtered.subreadset.xml')
@@ -266,7 +275,7 @@ def flow(config):
             inputs = {"i_dataset": dataset_pfn,},
             outputs = {"o_dataset": fdataset_pfn,},
             parameters = parameters,
-            TaskType = PypeThreadTaskBase,
+            TaskType = PypeTaskBase,
             URL = "task://localhost/filterbam")
     task = make_task(task_filterbam)
     wf.addTask(task)
@@ -277,7 +286,7 @@ def flow(config):
             inputs = {"dataset": fdataset_pfn,},
             outputs =  {"fasta": orig_fasta_pfn,},
             parameters = parameters,
-            TaskType = PypeThreadTaskBase,
+            TaskType = PypeTaskBase,
             URL = "task://localhost/bam2fasta")
     task = make_task(task_bam2fasta)
     wf.addTask(task)
@@ -289,7 +298,7 @@ def flow(config):
             inputs =  {"orig_fasta": orig_fasta_pfn,},
             outputs =  {"asm_fasta": asm_fasta_pfn,},
             parameters = parameters,
-            TaskType = PypeThreadTaskBase,
+            TaskType = PypeTaskBase,
             URL = "task://localhost/falcon")
     #task = make_task(task_falcon)
     #wf.addTask(task)
@@ -302,7 +311,7 @@ def flow(config):
             inputs =  {"fasta": asm_fasta_pfn,},
             outputs = {"referenceset": referenceset_pfn,},
             parameters = parameters,
-            TaskType = PypeThreadTaskBase,
+            TaskType = PypeTaskBase,
             URL = "task://localhost/fasta2referenceset")
     task = make_task(task_fasta2referenceset)
     wf.addTask(task)
@@ -320,7 +329,7 @@ def flow(config):
                       "referenceset": referenceset_pfn,},
             outputs = {"alignmentset": alignmentset_pfn,},
             parameters = parameters,
-            TaskType = PypeThreadTaskBase,
+            TaskType = PypeTaskBase,
             URL = "task://localhost/pbalign")
     task = make_task(task_pbalign)
     wf.addTask(task)
@@ -343,7 +352,7 @@ def flow(config):
                 #"consensus_contigset": consensus_contigset_pfn,
             },
             parameters = parameters,
-            TaskType = PypeThreadTaskBase,
+            TaskType = PypeTaskBase,
             URL = "task://localhost/genomic_consensus")
     task = make_task(task_genomic_consensus)
     wf.addTask(task)
@@ -363,7 +372,7 @@ def flow(config):
                       "gathered_alignmentset": gathered_alignmentset_pfn,},
             outputs = {"alignment_summary_gff": alignment_summary_gff_pfn,},
             parameters = parameters,
-            TaskType = PypeThreadTaskBase,
+            TaskType = PypeTaskBase,
             URL = "task://localhost/summarize_coverage")
     task = make_task(task_summarize_coverage)
     #wf.addTask(task)
@@ -375,7 +384,7 @@ def flow(config):
                       #"gathered_fastq": gathered_fastq_pfn,},
             outputs = {"polished_assembly_report_json": polished_assembly_report_json_pfn,},
             parameters = parameters,
-            TaskType = PypeThreadTaskBase,
+            TaskType = PypeTaskBase,
             URL = "task://localhost/polished_assembly_report")
     task = make_task(task_polished_assembly_report)
     #wf.addTask(task)
@@ -392,7 +401,7 @@ def flow(config):
             inputs = {"foo1": foo_fn1,},
             outputs =  {"foo2": foo_fn2,},
             parameters = parameters,
-            TaskType = PypeThreadTaskBase,
+            TaskType = PypeTaskBase,
             URL = "task://localhost/foo")
     task = make_task(task_foo)
     wf.addTask(task)

--- a/pbfalcon/pypeflow/flow.py
+++ b/pbfalcon/pypeflow/flow.py
@@ -3,6 +3,7 @@ from .. import sys
 
 from pbcore.io import (SubreadSet, HdfSubreadSet, FastaReader, FastaWriter,
                        FastqReader, FastqWriter)
+from pbcoretools.tasks.converters import run_bam_to_fasta
 from pypeflow.pwatcher_bridge import PypeProcWatcherWorkflow, MyFakePypeThreadTaskBase
 from pypeflow.controller import PypeThreadWorkflow
 from pypeflow.data import PypeLocalFile, makePypeLocalFile, fn
@@ -23,11 +24,13 @@ PypeTaskBase = MyFakePypeThreadTaskBase
 def say(x):
     log.warning(x)
     print 'IN FLOW!'
-def run_bam_to_fastx(program_name, fastx_reader, fastx_writer,
+def HOLD_run_bam_to_fastx(program_name, fastx_reader, fastx_writer,
                      input_file_name, output_file_name,
                      min_subread_length=0):
     """Copied from pbsmrtpipe/pb_tasks/pacbio.py,
     with minor changes.
+    That was later moved to pbcoretools/tasks/converters.py,
+    and that was recently changed enough that something here is completely broken.
     """
     # XXX this is really annoying; bam2fastx needs a --no-gzip feature
     #tmp_out_prefix = tempfile.NamedTemporaryFile().name
@@ -212,9 +215,10 @@ def task_bam2fasta(self):
     #sys.system('touch {}'.format(fn(self.fasta)))
     input_file_name = fn(self.dataset)
     output_file_name = fn(self.fasta)
-    run_bam_to_fastx('bam2fasta', FastaReader, FastaWriter,
-                     input_file_name, output_file_name,
-                     min_subread_length=0)
+    #run_bam_to_fastx('bam2fasta', FastaReader, FastaWriter,
+    #                 input_file_name, output_file_name,
+    #                 min_subread_length=0)
+    run_bam_to_fasta(input_file_name, output_file_name)
 def task_falcon(self):
     input_file_name = fn(self.orig_fasta)
     output_file_name = fn(self.asm_fasta)

--- a/pbfalcon/pypeflow/hgap.py
+++ b/pbfalcon/pypeflow/hgap.py
@@ -155,6 +155,10 @@ DEFAULT_OPTIONS = """
     "other_filters": "rq >= 0.7, length lte 50000",
     "read_length": 1
   },
+  "pbreports.tasks.summarize_coverage": {
+    "options": "--num_regions 1000 --region_size 0",
+    "~comment": "--force_num_regions"
+  },
   "pbsmrtpipe": {
     "~comment": "Overrides for pbsmrtpipe"
   },

--- a/pbfalcon/pypeflow/hgap.py
+++ b/pbfalcon/pypeflow/hgap.py
@@ -123,6 +123,7 @@ DEFAULT_OPTIONS = """
     "SuppressAuto": true,
     "GenomeSize": 8000,
     "min_length_cutoff": 1,
+    "job_type": "local",
     "~comment": "Overrides for full HGAP pipeline"
   },
   "falcon": {

--- a/pbfalcon/pypeflow/hgap.py
+++ b/pbfalcon/pypeflow/hgap.py
@@ -143,7 +143,7 @@ DEFAULT_OPTIONS = """
   },
   "pbalign": {
     "options": "--hitPolicy randombest --minAccuracy 70.0 --minLength 50 --algorithm=blasr",
-    "algorithmOptions": "-minMatch 12 -bestn 10 -minPctSimilarity 70.0",
+    "algorithmOptions": "--minMatch 12 --bestn 10 --minPctSimilarity 70.0",
     "_jdnotes": "--maxHits 1 --minAnchorSize 12 --maxDivergence=30 --minAccuracy=0.75 --minLength=50 --hitPolicy=random --seed=1",
     "~comment": "Overrides for blasr alignment (prior to polishing)"
   },

--- a/pbfalcon/pypeflow/hgap.py
+++ b/pbfalcon/pypeflow/hgap.py
@@ -211,8 +211,8 @@ def update2(start, updates):
                 continue
             start[key1][key2] = copy.deepcopy(val2)
 
-def run(input_config_fn, logging_config_fn=None):
-    global log
+def run(input_config_fn, logging_config_fn):
+    #global log
     #import logging_tree
     #logging_tree.printout()
     setup_logger(logging_config_fn)

--- a/pbfalcon/sys.py
+++ b/pbfalcon/sys.py
@@ -26,11 +26,18 @@ def symlink(actual, symbolic=None):
     symbolic name is basename(actual) if not provided.
     """
     symbolic = os.path.basename(actual) if not symbolic else symbolic
+    assert os.path.abspath(actual) != os.path.abspath(symbolic), '{!r} == {!r}'.format(actual, symbolic)
     rel = os.path.relpath(actual)
     lg('ln -s %s %s' %(rel, symbolic))
     if os.path.lexists(symbolic):
         os.unlink(symbolic)
     os.symlink(rel, symbolic)
+
+def unlink(*fns):
+    for fn in fns:
+        if os.path.lexists(fn):
+            #lg('rm -f {}'.format(fn))
+            os.unlink(fn)
 
 def system(cmd):
     lg('system(%s)' %repr(cmd))

--- a/pbfalcon/tasks/basic.py
+++ b/pbfalcon/tasks/basic.py
@@ -29,6 +29,7 @@ FT_FASTA = FileTypes.FASTA
 FT_REPORT = FileTypes.REPORT
 
 def FT(file_type, basename, title):
+    # (file_type_id, label, display_name, description, default_name)
     return OutputFileType(file_type.file_type_id,
                           basename + '_id',
                           title,
@@ -115,8 +116,8 @@ def run_rtc(rtc):
 @registry('task_hgap_run', '0.0.0',
         [FT_JSON, FT_JSON, FT_SUBREADS],
         [FT_FASTA_OUT,
-            #FT(FT_REPORT, 'preassembly_rpt', "Preassembly report"),
-            #FT(FT_REPORT, 'polished_assembly', "Preassembly report"),
+         FT(FT_REPORT, 'preassembly_rpt', "Preassembly report"),
+         FT(FT_REPORT, 'polished_assembly_rpt', "Polished aassembly report"),
         ],
         is_distributed=False)
 def run_rtc(rtc):

--- a/pbfalcon/tasks/basic.py
+++ b/pbfalcon/tasks/basic.py
@@ -25,6 +25,7 @@ FT_CFG = FileTypes.CFG
 FT_BASH = FileTypes.TXT
 FT_DUMMY = FileTypes.TXT
 FT_SUBREADS = FileTypes.DS_SUBREADS
+FT_CONTIGS = FileTypes.DS_CONTIG
 FT_FASTA = FileTypes.FASTA
 FT_REPORT = FileTypes.REPORT
 
@@ -51,6 +52,11 @@ FT_FASTA_OUT = OutputFileType(FileTypes.FASTA.file_type_id,
                               "FASTA",
                               "FASTA sequences",
                               "reads")
+FT_CONTIGS_OUT = OutputFileType(FileTypes.DS_CONTIG.file_type_id,
+                              "contig_id",
+                              "contigset",
+                              "Contigset of polished FASTA sequences",
+                              "polished.contigset")
 
 @registry('task_falcon_config_get_fasta', '0.0.0', [FT_CFG], [FT_FOFN_OUT], is_distributed=False)
 def run_rtc(rtc):
@@ -115,7 +121,7 @@ def run_rtc(rtc):
 
 @registry('task_hgap_run', '0.0.0',
         [FT_JSON, FT_JSON, FT_SUBREADS],
-        [FT_FASTA_OUT,
+        [FT_CONTIGS_OUT,
          FT(FT_REPORT, 'preassembly_rpt', "Preassembly report"),
          FT(FT_REPORT, 'polished_assembly_rpt', "Polished aassembly report"),
         ],

--- a/pbfalcon/tusks.py
+++ b/pbfalcon/tusks.py
@@ -404,17 +404,15 @@ def run_falcon_asm(input_files, output_files):
 
 def run_hgap(input_files, output_files):
     i_cfg_fn, i_logging_fn, i_subreadset_fn = input_files
-    o_fasta_fn, = output_files
-    # Update the cfg with our subreadset.
+    o_contigset_fn, o_preass_json_fn, o_polass_json_fn, = output_files
+    # Update the cfg with our subreadset. (Inside hgap_run?)
     # Run pypeflow.hgap.main.
-    cmd = 'python -m pbfalcon.cli.hgap_run --logging {} {}'.format(i_logging_fn, i_cfg_fn)
-    #cmd = 'python -m pbfalcon.cli.hgap_run {}'.format(i_cfg_fn)
+    cmd = 'python -m pbfalcon.cli.hgap_run --logging {i_logging_fn} {i_cfg_fn}'.format(**locals())
     system(cmd)
-    final_asm_fn = os.path.join('2-asm-falcon', 'p_ctg.fa') # TODO: Polish!
-    cmd = 'mkdir -p %s; touch %s' %(os.path.dirname(final_asm_fn), final_asm_fn)
-    system(cmd)
-    # Link the output fasta to the final assembly of HGAP.
-    symlink(final_asm_fn, o_fasta_fn)
+    # Symlink expected outputs, by convention.
+    symlink('contigset.xml', o_contigset_fn)
+    symlink('pre_assembly_report.json', o_preass_json_fn)
+    symlink('polished_assembly_report.json', o_polass_json_fn)
     return 0
 
 def run_report_preassembly_yield(input_files, output_files):


### PR DESCRIPTION
This performs the entire HGAP workflow. It does not yet distribute jobs though. Works for me locally. It will be used in 'hgap5' tests in Jenkins. Not yet used in GUI.

Oh, this also add `-a` to the **DBsplit** defaults. Not sure if that's wise, but it's easy to revert that single commit. The DBsplit filter was supposed to do that always, but it was written wrong. (My bad.) I still need to fix the pre-assembly report to respect the presence or absence of `-a`.