### PR TITLE
Remove hard-coded jsmenv paths

### DIFF
--- a/utest/test_hgap_prepare.py
+++ b/utest/test_hgap_prepare.py
@@ -1,5 +1,5 @@
 from pbfalcon import hgap_prepare as mod
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_raises
 from StringIO import StringIO
 
 def test_learn_job_type_old():
@@ -9,7 +9,7 @@ def test_learn_job_type_old():
 
 def test_learn_jmsenv_ish_from_cluster_sh():
     jmsenv_ish = mod.learn_jmsenv_ish_from_cluster_sh(script_new)
-    expected = "/pbi/dept/secondary/siv/smrtlink/smrtlink-bihourly/smrtsuite_183743/userdata/generated/config/jmsenv/jmsenv.ish"
+    expected = "/pbi/dept/secondary/siv/smrtlink/smrtlink-nightly/smrtsuite_186224/userdata/generated/config/jmsenv/jmsenv.ish"
     assert_equal(jmsenv_ish, expected)
 
 def test_learn_job_type_from_jmsenv_ish():
@@ -21,10 +21,13 @@ QUEUE=prod66
     assert_equal(job_type, 'sge')
     assert_equal(sge_option, 'prod66')
 
-def _learn_job_type_new():
+    assert_raises(Exception, mod.learn_job_type_from_jmsenv_ish, 'BAD_INPUT')
+
+def est_learn_job_type_new():
     """We cannot run this because it makes a system call to an installed script,
     which will probably disappear soon.
     """
+    #job_type, sge_option = mod.learn_job_type(StringIO('foo')) #script_new))
     job_type, sge_option = mod.learn_job_type(StringIO(script_new))
     assert_equal(job_type, 'sge')
     assert_equal(sge_option, 'prod66')
@@ -47,12 +50,14 @@ script_new = """\
 set -o errexit
 set -o pipefail
 set -o nounset
-/pbi/dept/secondary/siv/smrtlink/smrtlink-bihourly/smrtsuite_183743/install/smrtlink-incremental_3.2.0.183743,183743-183743-183733-183698-183698/admin/bin/runjmscmd \
+/pbi/dept/secondary/siv/smrtlink/smrtlink-nightly/smrtsuite_186224/install/smrtlink-fromsrc_3.2.0.186224,186224-186224-186144-186144-186112/admin/bin/runjmscmd \
     --start \
-    --jmsenv "/pbi/dept/secondary/siv/smrtlink/smrtlink-bihourly/smrtsuite_183743/userdata/generated/config/jmsenv/jmsenv.ish" \
-    --jobname job.2355224falcon_ns.tasks.task_hgap_prepare \
-    --stdoutfile "/pbi/dept/secondary/siv/smrtlink/smrtlink-bihourly/smrtsuite_183743/userdata/jobs_root/000/000189/tasks/falcon_ns.tasks.task_hgap_prepare-0/cluster.stdout" \
-    --stderrfile "/pbi/dept/secondary/siv/smrtlink/smrtlink-bihourly/smrtsuite_183743/userdata/jobs_root/000/000189/tasks/falcon_ns.tasks.task_hgap_prepare-0/cluster.stderr" \
-    --nproc "23" \
-    --cmd "/pbi/dept/secondary/siv/smrtlink/smrtlink-bihourly/smrtsuite_183743/userdata/jobs_root/000/000189/tasks/falcon_ns.tasks.task_hgap_prepare-0/run.sh"
+    --jmsenv "/pbi/dept/secondary/siv/smrtlink/smrtlink-nightly/smrtsuite_186224/userdata/generated/config/jmsenv/jmsenv.ish" \
+    --jobname job.5431233falcon_ns.tasks.task_hgap_prepare \
+    --stdoutfile "/pbi/dept/secondary/siv/smrtlink/smrtlink-nightly/smrtsuite_186224/userdata/jobs_root/000/000259/tasks/falcon_ns.tasks.task_hgap_prepare-0/cluster.stdout" \
+    --stderrfile "/pbi/dept/secondary/siv/smrtlink/smrtlink-nightly/smrtsuite_186224/userdata/jobs_root/000/000259/tasks/falcon_ns.tasks.task_hgap_prepare-0/cluster.stderr" \
+    --nproc "16" \
+    --cmd "/pbi/dept/secondary/siv/smrtlink/smrtlink-nightly/smrtsuite_186224/userdata/jobs_root/000/000259/tasks/falcon_ns.tasks.task_hgap_prepare-0/run.sh"
+
+exit
 """


### PR DESCRIPTION
Test for bad regex match. Update tests to recent cluster.sh.

Will this work? Not sure. We needed the hard-coded path because at one
time pbsmrtpipe stopped using jmsenv. (I think it was reverted, and soon
un-reverted without fanfare.) But my tests definitely pass, including the system test (`est_learn_job_type_new()`, which I add-and-remove locally).

SE-64