### PR TITLE
Fix scatter_run_scripts_in_json dropping scripts.

### DIFF
--- a/utest/test_scatter.py
+++ b/utest/test_scatter.py
@@ -1,0 +1,15 @@
+from nose.tools import assert_equal
+from pbfalcon.tasks.scatter_run_scripts_in_json import num_items_in_chunks
+
+def test_num_items_in_chunks():
+    expected = [3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2]
+    got = num_items_in_chunks(28, 12)
+    assert_equal(expected, got)
+
+    expected = [1, 1]
+    got = num_items_in_chunks(2, 2)
+    assert_equal(expected, got)
+
+    expected = [4, 3]
+    got = num_items_in_chunks(7, 2)
+    assert_equal(expected, got)


### PR DESCRIPTION
scatter_run_scripts_in_json and scatter_run_scripts_in_json_2
may drop scripts in some cases. Fix it and add an utest.